### PR TITLE
test: add characterization tests for best-image, grouping, schemaorg-fill

### DIFF
--- a/tests/unit/plugins/best-image.test.ts
+++ b/tests/unit/plugins/best-image.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Characterization tests for BestImagePlugin.
+ *
+ * These tests pin the CURRENT behavior of the plugin's candidate collection
+ * and scoring logic. They do not assert the behavior is "correct" -- only
+ * that it is stable, so a later refactor (see #25) has a safety net.
+ */
+
+import { load } from "cheerio";
+import { describe, expect, it } from "vitest";
+import { BestImagePlugin } from "../../../src/plugins/best-image";
+
+function wrapImage(returnValue: unknown) {
+  const decorated = function image() {
+    return returnValue;
+  };
+  return BestImagePlugin.run(decorated as never);
+}
+
+function makeScraper(overrides: Record<string, unknown> = {}) {
+  return {
+    bestImageSelection: true,
+    schema: undefined,
+    $: undefined,
+    ...overrides,
+  };
+}
+
+describe("BestImagePlugin", () => {
+  it("returns the decorated value unchanged when bestImageSelection is false", () => {
+    const wrapped = wrapImage("https://example.com/original.jpg");
+    const result = wrapped.call(makeScraper({ bestImageSelection: false }));
+    expect(result).toBe("https://example.com/original.jpg");
+  });
+
+  it("returns the primary image unchanged when no candidates are found", () => {
+    const wrapped = wrapImage("");
+    const result = wrapped.call(makeScraper());
+    expect(result).toBe("");
+  });
+
+  it("prefers the candidate with the larger area", () => {
+    const wrapped = wrapImage("http://example.com/a.jpg");
+    const scraper = makeScraper({
+      schema: {
+        data: {
+          image: {
+            url: "https://example.com/b.jpg",
+            width: 800,
+            height: 600,
+          },
+        },
+      },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/b.jpg");
+  });
+
+  it("prefers https over http when areas tie", () => {
+    const wrapped = wrapImage("http://example.com/a.jpg");
+    const scraper = makeScraper({
+      schema: { data: { image: { url: "https://example.com/b.jpg" } } },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/b.jpg");
+  });
+
+  it("prefers the earlier-registered candidate when area and security tie", () => {
+    const wrapped = wrapImage("https://example.com/a.jpg");
+    const scraper = makeScraper({
+      schema: { data: { image: { url: "https://example.com/b.jpg" } } },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/a.jpg");
+  });
+
+  it("parses dimensions embedded in the URL path", () => {
+    const wrapped = wrapImage("");
+    const scraper = makeScraper({
+      schema: {
+        data: {
+          image: [
+            "https://example.com/photo-1200x800.jpg",
+            "https://example.com/photo-100x100.jpg",
+          ],
+        },
+      },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/photo-1200x800.jpg");
+  });
+
+  it("parses dimensions from width/height query parameters", () => {
+    const wrapped = wrapImage("https://example.com/dimensionless.jpg");
+    const scraper = makeScraper({
+      schema: { data: { image: "https://example.com/i.jpg?w=1000&h=900" } },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/i.jpg?w=1000&h=900");
+  });
+
+  it("collects OpenGraph image candidates from meta tags", () => {
+    const html = `
+      <html><head>
+        <meta property="og:image" content="https://example.com/og.jpg">
+        <meta property="og:image:width" content="2000">
+        <meta property="og:image:height" content="1500">
+      </head></html>
+    `;
+    const wrapped = wrapImage("https://example.com/primary.jpg");
+    const scraper = makeScraper({ $: load(html) });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/og.jpg");
+  });
+
+  it("merges duplicate URLs across sources, keeping the maximum known dimensions", () => {
+    const html = `
+      <html><head>
+        <meta property="og:image" content="https://example.com/shared.jpg">
+        <meta property="og:image:width" content="500">
+        <meta property="og:image:height" content="500">
+      </head></html>
+    `;
+    const wrapped = wrapImage("https://example.com/shared.jpg");
+    const scraper = makeScraper({
+      schema: {
+        data: {
+          image: {
+            url: "https://example.com/small.jpg",
+            width: 10,
+            height: 10,
+          },
+        },
+      },
+      $: load(html),
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/shared.jpg");
+  });
+
+  it("parses width/height objects with a value property", () => {
+    const wrapped = wrapImage("https://example.com/primary2.jpg");
+    const scraper = makeScraper({
+      schema: {
+        data: {
+          image: {
+            url: "https://example.com/c.jpg",
+            width: { value: "640" },
+            height: { value: "480" },
+          },
+        },
+      },
+    });
+    const result = wrapped.call(scraper);
+    expect(result).toBe("https://example.com/c.jpg");
+  });
+});

--- a/tests/unit/plugins/schemaorg-fill.test.ts
+++ b/tests/unit/plugins/schemaorg-fill.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Characterization tests for SchemaOrgFillPlugin.
+ *
+ * These tests pin the CURRENT behavior of the schema.org fallback wrapper.
+ * They do not assert the behavior is "correct" -- only that it is stable, so
+ * a later refactor (see #25) has a safety net.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  FillPluginException,
+  NotImplementedError,
+  RecipeSchemaNotFound,
+} from "../../../src/exceptions";
+import { SchemaOrgFillPlugin } from "../../../src/plugins/schemaorg-fill";
+
+function makeWrapped(fn: (...args: unknown[]) => unknown) {
+  return SchemaOrgFillPlugin.run(fn as never);
+}
+
+describe("SchemaOrgFillPlugin", () => {
+  it("returns the decorated method's value when it succeeds", () => {
+    const wrapped = makeWrapped(function title() {
+      return "Direct Title";
+    });
+    const result = wrapped.call({
+      schema: undefined,
+      url: "https://example.com",
+    });
+    expect(result).toBe("Direct Title");
+  });
+
+  it("falls back to the schema method when NotImplementedError is thrown", () => {
+    const wrapped = makeWrapped(function title() {
+      throw new NotImplementedError("not implemented");
+    });
+    const schema = { data: {}, title: () => "From Schema" };
+    const result = wrapped.call({ schema, url: "https://example.com" });
+    expect(result).toBe("From Schema");
+  });
+
+  it("falls back to the schema method when FillPluginException is thrown", () => {
+    const wrapped = makeWrapped(function title() {
+      throw new FillPluginException("try schema");
+    });
+    const schema = { data: {}, title: () => "From Schema" };
+    const result = wrapped.call({ schema, url: "https://example.com" });
+    expect(result).toBe("From Schema");
+  });
+
+  it("throws RecipeSchemaNotFound when no schema data exists", () => {
+    const wrapped = makeWrapped(function title() {
+      throw new NotImplementedError("not implemented");
+    });
+    expect(() =>
+      wrapped.call({ schema: undefined, url: "https://example.com" })
+    ).toThrow(RecipeSchemaNotFound);
+  });
+
+  it("rethrows unrelated errors without attempting a schema fallback", () => {
+    const wrapped = makeWrapped(function title() {
+      throw new Error("boom");
+    });
+    const schema = { data: {}, title: () => "From Schema" };
+    expect(() => wrapped.call({ schema, url: "https://example.com" })).toThrow(
+      "boom"
+    );
+  });
+
+  it("rethrows the original error when schema has no matching method", () => {
+    const wrapped = makeWrapped(function title() {
+      throw new NotImplementedError("not implemented");
+    });
+    const schema = { data: {} };
+    expect(() => wrapped.call({ schema, url: "https://example.com" })).toThrow(
+      NotImplementedError
+    );
+  });
+});

--- a/tests/unit/utils/grouping.test.ts
+++ b/tests/unit/utils/grouping.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Characterization tests for groupIngredients.
+ *
+ * These tests pin the CURRENT behavior of ingredient grouping (default
+ * selector probing, count-mismatch errors, and fuzzy text matching). They do
+ * not assert the behavior is "correct" -- only that it is stable, so a later
+ * refactor (see #25) has a safety net.
+ */
+
+import { load } from "cheerio";
+import { describe, expect, it } from "vitest";
+import { groupIngredients } from "../../../src/utils/grouping";
+
+const COUNT_MISMATCH_PATTERN =
+  /Found 3 grouped ingredients but was expecting to find 2\./;
+
+describe("groupIngredients", () => {
+  it("returns a single ungrouped entry when no default selectors match", () => {
+    const $ = load("<html><body><p>hello</p></body></html>");
+    const list = ["one", "two"];
+    const result = groupIngredients(list, $);
+    expect(result).toEqual([{ purpose: null, ingredients: list }]);
+  });
+
+  it("returns an empty ungrouped entry for an empty ingredients list", () => {
+    const $ = load("<div/>");
+    const result = groupIngredients([], $);
+    expect(result).toEqual([{ purpose: null, ingredients: [] }]);
+  });
+
+  it("groups ingredients using the default wprm selectors", () => {
+    const html = `
+      <div class="wprm-recipe-ingredient-group"><h4>Sauce</h4></div>
+      <ul>
+        <li class="wprm-recipe-ingredient">1/2 cup soy sauce</li>
+        <li class="wprm-recipe-ingredient">1 tbsp honey</li>
+      </ul>
+    `;
+    const $ = load(html);
+    const list = ["1/2 cup soy sauce", "1 tbsp honey"];
+    const result = groupIngredients(list, $);
+    expect(result).toEqual([{ purpose: "Sauce", ingredients: list }]);
+  });
+
+  it("throws when the grouped element count does not match the ingredients list", () => {
+    const html = `
+      <div class="wprm-recipe-ingredient-group"><h4>Sauce</h4></div>
+      <ul>
+        <li class="wprm-recipe-ingredient">a</li>
+        <li class="wprm-recipe-ingredient">b</li>
+        <li class="wprm-recipe-ingredient">c</li>
+      </ul>
+    `;
+    const $ = load(html);
+    expect(() => groupIngredients(["a", "b"], $)).toThrow(
+      COUNT_MISMATCH_PATTERN
+    );
+  });
+
+  it("groups ingredients using explicitly provided selectors", () => {
+    const html = `
+      <div class="custom-group"><span class="custom-heading">Dressing</span></div>
+      <ul>
+        <li class="custom-item">olive oil</li>
+        <li class="custom-item">vinegar</li>
+      </ul>
+    `;
+    const $ = load(html);
+    const list = ["olive oil", "vinegar"];
+    const result = groupIngredients(
+      list,
+      $,
+      ".custom-group .custom-heading",
+      ".custom-item"
+    );
+    expect(result).toEqual([{ purpose: "Dressing", ingredients: list }]);
+  });
+
+  it("matches unicode fraction glyphs in DOM text to their ascii-fraction list entries", () => {
+    const html = `
+      <div class="custom-group"><span class="custom-heading">Sugar</span></div>
+      <ul><li class="custom-item">½ cup sugar</li></ul>
+    `;
+    const $ = load(html);
+    const list = ["1/2 cup sugar"];
+    const result = groupIngredients(
+      list,
+      $,
+      ".custom-group .custom-heading",
+      ".custom-item"
+    );
+    expect(result).toEqual([
+      { purpose: "Sugar", ingredients: ["1/2 cup sugar"] },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #22

## Summary

Adds 22 characterization tests pinning the current behavior of three modules scheduled for complexity refactors in #25, none of which had any test coverage:

- `tests/unit/plugins/best-image.test.ts` (10 tests) — candidate collection and scoring through the `BestImagePlugin.run` wrapper: the `bestImageSelection` gate, area/https/insertion-order ranking, dimension parsing from URL paths (`-1200x800`), query params (`?w=&h=`), and `{value}` objects, OpenGraph meta collection, and duplicate-URL dimension merging.
- `tests/unit/utils/grouping.test.ts` (6 tests) — `groupIngredients` default wprm selector probing, ungrouped fallback, empty-list early return, count-mismatch error, explicit selectors, and unicode-fraction (`½` → `1/2`) matching.
- `tests/unit/plugins/schemaorg-fill.test.ts` (6 tests) — `SchemaOrgFillPlugin.run` fallback semantics: success path, `NotImplementedError`/`FillPluginException` → schema fallback, `RecipeSchemaNotFound` when schema data is missing, and rethrow behavior for unrelated errors and missing schema methods.

These are characterization tests: they pin behavior as-is (no `src/` changes) so the #25 refactors have a safety net.

## Verification

- `bun run test` → 290 passed (268 baseline + 22 new), exit 0
- `bun run type-check` → exit 0
- `bun x ultracite check` → 88 errors (exactly the `f53cc0c` baseline; new files contribute zero)

Executed from the plan in #22 (reviewed executor run; full report in the issue comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)